### PR TITLE
UIEXT-3553: Moved getCredentialsProvider to public interface

### DIFF
--- a/org.knime.bigdata.databricks/src/org/knime/bigdata/dbfs/filehandling/node/DbfsConnectorNodeParameters.java
+++ b/org.knime.bigdata.databricks/src/org/knime/bigdata/dbfs/filehandling/node/DbfsConnectorNodeParameters.java
@@ -75,7 +75,6 @@ import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 import org.knime.core.node.util.CheckUtils;
 import org.knime.core.node.workflow.CredentialsProvider;
-import org.knime.core.webui.node.dialog.defaultdialog.impl.NodeParametersInputImpl;
 import org.knime.node.parameters.widget.file.customfilesystem.FSConnectionProvider;
 import org.knime.node.parameters.widget.file.FileSelectionWidget;
 import org.knime.node.parameters.widget.file.SingleFileSelectionMode;
@@ -345,7 +344,7 @@ class DbfsConnectorNodeParameters implements NodeParameters {
         }
 
         private static CredentialsProvider getCredentialsProvider(final NodeParametersInput input) {
-            return ((NodeParametersInputImpl)input).getCredentialsProvider().orElseThrow();
+            return input.getCredentialsProvider().orElseThrow();
         }
 
     }

--- a/org.knime.bigdata.hadoop.filehandling.knox/src/org/knime/bigdata/hadoop/filehandling/knox/node/KnoxHdfsConnectorNodeParameters.java
+++ b/org.knime.bigdata.hadoop.filehandling.knox/src/org/knime/bigdata/hadoop/filehandling/knox/node/KnoxHdfsConnectorNodeParameters.java
@@ -62,7 +62,6 @@ import org.knime.core.node.NodeSettingsRO;
 import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.util.CheckUtils;
 import org.knime.core.node.workflow.CredentialsProvider;
-import org.knime.core.webui.node.dialog.defaultdialog.impl.NodeParametersInputImpl;
 import org.knime.node.parameters.widget.file.customfilesystem.FSConnectionProvider;
 import org.knime.node.parameters.widget.file.FileSelectionWidget;
 import org.knime.node.parameters.widget.file.SingleFileSelectionMode;
@@ -246,7 +245,7 @@ class KnoxHdfsConnectorNodeParameters implements NodeParameters {
         }
 
         private static CredentialsProvider getCredentialsProvider(final NodeParametersInput input) {
-            return ((NodeParametersInputImpl) input).getCredentialsProvider().orElseThrow();
+            return input.getCredentialsProvider().orElseThrow();
         }
 
     }


### PR DESCRIPTION
UIEXT-3553 (Move getCredentialsProvider to the public NodeParametersInput interface)